### PR TITLE
Add flag to enable dynamic increment of accounts

### DIFF
--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -92,7 +92,7 @@ func runAirdrop(c *cli.Context) error {
 	}
 	txPerAccount := config.N
 	airdropValue := new(big.Int).Mul(big.NewInt(int64(txPerAccount*100000)), big.NewInt(params.GWei))
-	spammer.Airdrop(config, airdropValue)
+	spammer.Airdrop(config, airdropValue, 100)
 	return nil
 }
 
@@ -100,14 +100,22 @@ func spam(config *spammer.Config, spamFn spammer.Spam, airdropValue *big.Int) er
 	// Make sure the accounts are unstuck before sending any transactions
 	fmt.Println("Unstucking")
 	spammer.Unstuck(config)
+
+	spamCount := 0
+
 	for {
-		fmt.Println("Airdropping")
-		if err := spammer.Airdrop(config, airdropValue); err != nil {
-			return err
+		if spamCount%config.AccountsIncrementIntervalFlag == 0 { // Reduce the frequency of airdrop
+			fmt.Println("Airdropping")
+			value := new(big.Int).Mul(big.NewInt(50), airdropValue)
+			if err := spammer.Airdrop(config, value, spamCount); err != nil {
+				return err
+			}
 		}
+
 		fmt.Println("Spamming")
-		spammer.SpamTransactions(config, spamFn)
+		spammer.SpamTransactions(config, spamFn, spamCount)
 		time.Sleep(time.Duration(config.SlotTime) * time.Second)
+		spamCount += 1
 	}
 }
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -44,6 +44,12 @@ var (
 		Value: 0,
 	}
 
+	AccountsIncrementIntervalFlag = &cli.IntFlag{
+		Name:  "accounts_increment_interval",
+		Usage: "Number of blocks before the account used per block increments",
+		Value: 0,
+	}
+
 	GasLimitFlag = &cli.IntFlag{
 		Name:  "gaslimit",
 		Usage: "Gas limit used for transactions",
@@ -63,6 +69,7 @@ var (
 		CorpusFlag,
 		RpcFlag,
 		TxCountFlag,
+		AccountsIncrementIntervalFlag,
 		CountFlag,
 		GasLimitFlag,
 		SlotTimeFlag,

--- a/spammer/addresslist.go
+++ b/spammer/addresslist.go
@@ -143,7 +143,7 @@ func CreateAddresses(N int) ([]string, []string) {
 	return keys, addrs
 }
 
-func Airdrop(config *Config, value *big.Int) error {
+func Airdrop(config *Config, value *big.Int, spamCount int) error {
 	backend := ethclient.NewClient(config.backend)
 	sender := crypto.PubkeyToAddress(config.faucet.PublicKey)
 	fmt.Printf("Airdrop faucet is at %x\n", sender)
@@ -153,7 +153,19 @@ func Airdrop(config *Config, value *big.Int) error {
 		fmt.Printf("error getting chain ID; could not airdrop: %v\n", err)
 		return err
 	}
-	for _, addr := range config.keys {
+
+	keyCount := len(config.keys)
+	// Setup tx count
+	accInc := config.AccountsIncrementIntervalFlag
+	if accInc != 0 {
+		keyCount = spamCount / accInc
+	}
+	if keyCount == 0 {
+		keyCount = 1
+	}
+
+	keys := config.keys[:keyCount]
+	for _, addr := range keys {
 		nonce, err := backend.PendingNonceAt(context.Background(), sender)
 		if err != nil {
 			fmt.Printf("error getting pending nonce; could not airdrop: %v\n", err)

--- a/spammer/config.go
+++ b/spammer/config.go
@@ -22,13 +22,14 @@ import (
 type Config struct {
 	backend *rpc.Client // connection to the rpc provider
 
-	N          uint64              // number of transactions send per account
-	faucet     *ecdsa.PrivateKey   // private key of the faucet account
-	keys       []*ecdsa.PrivateKey // private keys of accounts
-	corpus     [][]byte            // optional corpus to use elements from
-	accessList bool                // whether to create accesslist transactions
-	gasLimit   uint64              // gas limit per transaction
-	SlotTime   uint64              // slot time in seconds
+	N                             uint64 // number of transactions send per account
+	AccountsIncrementIntervalFlag int
+	faucet                        *ecdsa.PrivateKey   // private key of the faucet account
+	keys                          []*ecdsa.PrivateKey // private keys of accounts
+	corpus                        [][]byte            // optional corpus to use elements from
+	accessList                    bool                // whether to create accesslist transactions
+	gasLimit                      uint64              // gas limit per transaction
+	SlotTime                      uint64              // slot time in seconds
 
 	seed int64            // seed used for generating randomness
 	mut  *mutator.Mutator // Mutator based on the seed
@@ -101,6 +102,7 @@ func NewConfigFromContext(c *cli.Context) (*Config, error) {
 	}
 
 	slotTime := c.Uint64(flags.SlotTimeFlag.Name)
+	accountsIncrementIntervalFlag := c.Int(flags.AccountsIncrementIntervalFlag.Name)
 
 	// Setup seed
 	seed := c.Int64(flags.SeedFlag.Name)
@@ -124,16 +126,17 @@ func NewConfigFromContext(c *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
-		backend:    backend,
-		N:          uint64(N),
-		faucet:     faucet,
-		accessList: !c.Bool(flags.NoALFlag.Name),
-		gasLimit:   uint64(gasLimit),
-		seed:       seed,
-		keys:       keys,
-		corpus:     corpus,
-		mut:        mut,
-		SlotTime:   slotTime,
+		backend:                       backend,
+		N:                             uint64(N),
+		AccountsIncrementIntervalFlag: accountsIncrementIntervalFlag,
+		faucet:                        faucet,
+		accessList:                    !c.Bool(flags.NoALFlag.Name),
+		gasLimit:                      uint64(gasLimit),
+		seed:                          seed,
+		keys:                          keys,
+		corpus:                        corpus,
+		mut:                           mut,
+		SlotTime:                      slotTime,
 	}, nil
 }
 

--- a/spammer/spam.go
+++ b/spammer/spam.go
@@ -11,13 +11,20 @@ import (
 
 type Spam func(*Config, *ecdsa.PrivateKey, *filler.Filler) error
 
-func SpamTransactions(config *Config, fun Spam) error {
-	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", config.N, len(config.keys), config.seed)
+func SpamTransactions(config *Config, fun Spam, spamCount int) error {
+	keyCount := len(config.keys)
 
-	errCh := make(chan error, len(config.keys))
+	// Setup tx count
+	accInc := config.AccountsIncrementIntervalFlag
+	if accInc != 0 {
+		keyCount = spamCount / accInc
+	}
+
+	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", config.N, keyCount, config.seed)
+	errCh := make(chan error, keyCount)
 	var wg sync.WaitGroup
-	wg.Add(len(config.keys))
-	for _, key := range config.keys {
+	wg.Add(keyCount)
+	for _, key := range config.keys[:keyCount] {
 		// Setup randomness uniquely per key
 		random := make([]byte, 10000)
 		config.mut.FillBytes(&random)


### PR DESCRIPTION
In tx-fuzz `accounts` number of account will send `txcounts` number of transactions in every slot. So, total number of tx per slot is `accounts * txcounts`. 

For high throughput blob testing, we want to increment the number of blobs during the lifespan of the fuzzer.

This PR adds a `accounts_increment_interval ` flag, which increments the `accounts` number every slot interval the user provides. This will increase the number of accounts that the transactions are sent from.

Ideally, we should have the number of transactions incremented. However, If we reach high blob throughput and send more than 16 blob tx per account, the mempool will reject the transaction. 

So, instead we can set `txcount=1` and slowly increment `accounts` from 0 to 72. 

to test this: 
```bash
go run ./cmd/livefuzzer/main.go blobs --no-al --rpc=rpc_endpoint --sk=private_key --accounts_increment_interval=1 --txcount=1
```